### PR TITLE
Avoid starting image stream when one is already streaming

### DIFF
--- a/lib/ui/camera_view.dart
+++ b/lib/ui/camera_view.dart
@@ -156,7 +156,9 @@ class _CameraViewState extends State<CameraView> with WidgetsBindingObserver {
         cameraController.stopImageStream();
         break;
       case AppLifecycleState.resumed:
-        await cameraController.startImageStream(onLatestImageAvailable);
+        if (!cameraController.value.isStreamingImages) {
+          await cameraController.startImageStream(onLatestImageAvailable);
+        }
         break;
       default:
     }


### PR DESCRIPTION
Fixes an exception occurring when the app resumes after it has not being paused.

On iOS this happens when the app is moved to the app switching (multitasking?) view by swiping slowly up then opening the app.