### PR TITLE
Ensure isolates are ready before using them with the camera

### DIFF
--- a/lib/ui/camera_view.dart
+++ b/lib/ui/camera_view.dart
@@ -42,7 +42,15 @@ class _CameraViewState extends State<CameraView> with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
+    initStateAsync();
+  }
+
+  void initStateAsync() async {
     WidgetsBinding.instance.addObserver(this);
+
+    // Spawn a new isolate
+    isolateUtils = IsolateUtils();
+    await isolateUtils.start();
 
     // Camera initialization
     initializeCamera();
@@ -52,10 +60,6 @@ class _CameraViewState extends State<CameraView> with WidgetsBindingObserver {
 
     // Initially predicting = false
     predicting = false;
-
-    // Spawn a new isolate
-    isolateUtils = IsolateUtils();
-    isolateUtils.start();
   }
 
   /// Initializes the camera by setting [cameraController]

--- a/lib/utils/isolate_utils.dart
+++ b/lib/utils/isolate_utils.dart
@@ -17,7 +17,7 @@ class IsolateUtils {
 
   SendPort get sendPort => _sendPort;
 
-  void start() async {
+  Future<void> start() async {
     _isolate = await Isolate.spawn<SendPort>(
       entryPoint,
       _receivePort.sendPort,


### PR DESCRIPTION
Moved all the `initState` code into an async method to be able to call await on `IsolateUtils.start()` and ensure it's fully set up before proceeding to initialise the camera. The cameras callbacks used the isolate which was causing a crash.