### PR TITLE
Kill isolate when camera is disposed

### DIFF
--- a/lib/ui/camera_view.dart
+++ b/lib/ui/camera_view.dart
@@ -172,6 +172,7 @@ class _CameraViewState extends State<CameraView> with WidgetsBindingObserver {
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     cameraController.dispose();
+    isolateUtils.stopIsolate();
     super.dispose();
   }
 }

--- a/lib/utils/isolate_utils.dart
+++ b/lib/utils/isolate_utils.dart
@@ -47,6 +47,10 @@ class IsolateUtils {
       }
     }
   }
+
+  void stopIsolate() {
+    _isolate.kill();
+  }
 }
 
 /// Bundles data to pass between Isolate


### PR DESCRIPTION
Hi,

I found a problem while trying to implement the project in a different flutter app. When you close the camera and open again, there is a leftover process. If you do it over and over again, it will eventually fill up memory. 

The problem is when camera is disposed, there's still an active isolate thread in the background. Therefore a simple fix was to kill the isolate on camera disposal.